### PR TITLE
[test] 테스트 세팅 및 회원가입/로그인 테스트 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '3.3.5'
 	id 'io.spring.dependency-management' version '1.1.6'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
-	id 'com.epages.restdocs-api-spec' version '0.18.2'
+	id 'com.epages.restdocs-api-spec' version '0.19.1'
 }
 
 group = 'app'
@@ -46,19 +46,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc' // Spring REST Docs: `.adoc` 형식 문서 생성
 	testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.1' // 테스트 실행 시 OpenAPI 문서 만들기 위한 API 정보 수집
-//	testImplementation 'com.epages:restdocs-api-spec-openapi3-generator:0.19.1' // OpenAPI 3.0 형식(JSON/YAML)으로 변환
 
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
-
-tasks.named('build') {
-	dependsOn tasks.named('openapi3')
-}
-
-tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
 }
 
 openapi3 {
@@ -68,6 +58,37 @@ openapi3 {
 	outputDirectory = "src/main/resources/public"
 	version = '0.1.0'
 	format = 'yaml'
+}
+
+tasks.register('bearerAuthentication') {
+	mustRunAfter tasks.named('openapi3')
+	doLast {
+		def apiSpecFile = file('src/main/resources/public/openapi3.yaml')
+		def contentToAdd =
+				"  securitySchemes:\n" +
+						"    bearerAuth:\n" +
+						"      type: http\n" +
+						"      scheme: bearer\n" +
+						"      bearerFormat: JWT\n" +
+						"\n" +
+						"security:\n" +
+						"  - bearerAuth: []"
+		def existingContent = apiSpecFile.text
+		def updatedContent = existingContent + contentToAdd
+		apiSpecFile.withWriter('UTF-8') {
+			writer -> writer.write(updatedContent)
+		}
+	}
+}
+
+tasks.named('build') {
+	dependsOn tasks.named('openapi3')
+	dependsOn tasks.named('bearerAuthentication')
+}
+
+tasks.named('test') {
+	outputs.dir snippetsDir
+	useJUnitPlatform()
 }
 
 postman {

--- a/build.gradle
+++ b/build.gradle
@@ -52,16 +52,19 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+tasks.named('build') {
+	dependsOn tasks.named('openapi3')
+}
+
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
 }
 
 openapi3 {
-	server = 'localhost:8080'
+	server = 'http://localhost:8080'
 	title = 'Pigrest API'
 	description = 'Pigrest API description'
-//	tagDescriptionsPropertiesFile = '/src/docs/tag-descriptions.yaml'
 	outputDirectory = "src/main/resources/public"
 	version = '0.1.0'
 	format = 'yaml'

--- a/src/main/java/app/pigrest/auth/controller/AuthController.java
+++ b/src/main/java/app/pigrest/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import app.pigrest.common.ApiResponse;
 import app.pigrest.common.ApiStatusCode;
 import app.pigrest.auth.dto.request.RegisterRequest;
 import app.pigrest.auth.service.AuthService;
+import app.pigrest.exception.DuplicateResourceException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -42,8 +43,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<RegisterResponse>> register(@Valid @RequestBody RegisterRequest request) {
         boolean isAvailable = authService.checkUsername(request.getUsername());
         if (!isAvailable) {
-            // TODO: Exception 변경
-            throw new IllegalArgumentException("Username is already in use");
+            throw new DuplicateResourceException("Username is already in use");
         }
 
         Auth auth = authService.create(request);

--- a/src/main/java/app/pigrest/auth/controller/AuthController.java
+++ b/src/main/java/app/pigrest/auth/controller/AuthController.java
@@ -5,10 +5,10 @@ import app.pigrest.auth.dto.request.LoginRequest;
 import app.pigrest.auth.dto.response.CheckUsernameResponse;
 import app.pigrest.auth.dto.response.LoginResponse;
 import app.pigrest.auth.dto.response.RegisterResponse;
+import app.pigrest.auth.model.Auth;
 import app.pigrest.auth.service.JwtService;
 import app.pigrest.common.ApiResponse;
 import app.pigrest.common.ApiStatusCode;
-import app.pigrest.member.model.Member;
 import app.pigrest.auth.dto.request.RegisterRequest;
 import app.pigrest.auth.service.AuthService;
 import jakarta.servlet.http.Cookie;
@@ -46,12 +46,12 @@ public class AuthController {
             throw new IllegalArgumentException("Username is already in use");
         }
 
-        Member member = authService.create(request);
+        Auth auth = authService.create(request);
         return ResponseEntity.ok(
                 ApiResponse.success(
                         ApiStatusCode.CREATED,
                         "Member registered successfully",
-                        RegisterResponse.from(member)));
+                        RegisterResponse.from(auth)));
     }
 
     @PostMapping("/login")

--- a/src/main/java/app/pigrest/auth/dto/request/LoginRequest.java
+++ b/src/main/java/app/pigrest/auth/dto/request/LoginRequest.java
@@ -1,9 +1,11 @@
 package app.pigrest.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class LoginRequest {
     @NotBlank(message = "Username must not be blank")
     private String username;

--- a/src/main/java/app/pigrest/auth/dto/request/RegisterRequest.java
+++ b/src/main/java/app/pigrest/auth/dto/request/RegisterRequest.java
@@ -1,12 +1,15 @@
 package app.pigrest.auth.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class RegisterRequest {
     @NotBlank(message = "Username must not be blank")
     @Size(min = 4, max = 16, message = "Username must be between 4 and 16 characters")
@@ -26,6 +29,7 @@ public class RegisterRequest {
     @Size(min = 4, max = 12, message = "Nickname must be between 4 and 12 characters")
     private String nickname;
 
+    @JsonIgnore
     @AssertTrue(message = "Password and confirmation must match")
     public boolean isPasswordMatching() {
         return password != null && password.equals(passwordConfirm);

--- a/src/main/java/app/pigrest/auth/dto/response/RegisterResponse.java
+++ b/src/main/java/app/pigrest/auth/dto/response/RegisterResponse.java
@@ -1,11 +1,11 @@
 package app.pigrest.auth.dto.response;
 
-import app.pigrest.member.model.Member;
+import app.pigrest.auth.model.Auth;
 
 public record RegisterResponse(
         String username
 ) {
-    public static RegisterResponse from(Member member) {
-        return new RegisterResponse(member.getNickname());
+    public static RegisterResponse from(Auth auth) {
+        return new RegisterResponse(auth.getUsername());
     }
 }

--- a/src/main/java/app/pigrest/auth/service/AuthService.java
+++ b/src/main/java/app/pigrest/auth/service/AuthService.java
@@ -1,6 +1,5 @@
 package app.pigrest.auth.service;
 
-import app.pigrest.auth.dto.request.CheckUsernameRequest;
 import app.pigrest.auth.dto.request.LoginRequest;
 import app.pigrest.auth.dto.request.RegisterRequest;
 import app.pigrest.auth.model.Auth;
@@ -25,7 +24,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public Member create(RegisterRequest request) {
+    public Auth create(RegisterRequest request) {
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         Auth auth = Auth.of(request.getUsername(), encodedPassword);
         Member member = Member.of(request.getUsername(), auth);
@@ -33,7 +32,7 @@ public class AuthService {
 
         authRepository.save(auth);
         memberRepository.save(member);
-        return member;
+        return auth;
     }
 
     public Authentication login(LoginRequest request) {

--- a/src/main/java/app/pigrest/auth/service/AuthService.java
+++ b/src/main/java/app/pigrest/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import app.pigrest.member.model.Member;
 import app.pigrest.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,12 +37,16 @@ public class AuthService {
     }
 
     public Authentication login(LoginRequest request) {
-        UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
-        Authentication authentication = authenticationManager.authenticate(authenticationToken);
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        try {
+            UsernamePasswordAuthenticationToken authenticationToken =
+                    new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword());
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        return authentication;
+            return authentication;
+        } catch (BadCredentialsException ex) {
+            throw new BadCredentialsException("Id or password is incorrect");
+        }
     }
 
     public boolean checkUsername(String username) {

--- a/src/main/java/app/pigrest/exception/DuplicateResourceException.java
+++ b/src/main/java/app/pigrest/exception/DuplicateResourceException.java
@@ -1,0 +1,10 @@
+package app.pigrest.exception;
+
+import app.pigrest.common.ApiStatusCode;
+
+public class DuplicateResourceException extends CustomException {
+    public DuplicateResourceException(String message) {
+        super(ApiStatusCode.DUPLICATE_RESOURCE, message);
+    }
+}
+

--- a/src/main/java/app/pigrest/exception/GlobalExceptionHandler.java
+++ b/src/main/java/app/pigrest/exception/GlobalExceptionHandler.java
@@ -19,6 +19,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.ok(ApiResponse.error(ex.getStatusCode(), ex.getMessage()));
     }
 
+    @ExceptionHandler(DuplicateResourceException.class)
+    public ResponseEntity<ApiResponse<Object>> handleDuplicateResourceException(DuplicateResourceException ex) {
+        return ResponseEntity.badRequest()
+                .body(ApiResponse.error(ex.getStatusCode(), ex.getMessage()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Object>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         String message = ex.getBindingResult().getFieldErrors().stream()

--- a/src/main/java/app/pigrest/exception/GlobalExceptionHandler.java
+++ b/src/main/java/app/pigrest/exception/GlobalExceptionHandler.java
@@ -2,7 +2,9 @@ package app.pigrest.exception;
 
 import app.pigrest.common.ApiResponse;
 import app.pigrest.common.ApiStatusCode;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -32,6 +34,12 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining(", "));
         return ResponseEntity.badRequest()
                 .body(ApiResponse.error(ApiStatusCode.VALIDATION_ERROR, message));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ApiResponse<Object>> handleAuthenticationException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error(ApiStatusCode.UNAUTHORIZED, ex.getMessage()));
     }
 
     // 그 외 모든 예외에 대해 처리 (예: NullPointerException, 기타 예상치 못한 예외)

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -13,10 +13,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
-  redis:
-    host: ${REDIS_HOST}
-    port: ${REDIS_PORT}
-    password: ${REDIS_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
 
 springdoc:
   api-docs:

--- a/src/test/java/app/pigrest/common/ApiResponseDocs.java
+++ b/src/test/java/app/pigrest/common/ApiResponseDocs.java
@@ -1,0 +1,32 @@
+package app.pigrest.common;
+
+import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class ApiResponseDocs {
+    public static final List<FieldDescriptor> COMMON_RESPONSE_FIELDS = List.of(
+            fieldWithPath("status").description("상태 코드").type(SimpleType.NUMBER),
+            fieldWithPath("message").description("상세 메시지").type(SimpleType.STRING),
+            fieldWithPath("timestamp").description("응답 시간").type(SimpleType.STRING),
+            fieldWithPath("error").description("에러 메시지").type(SimpleType.STRING).optional(),
+            fieldWithPath("data").description("응답 데이터").type(JsonFieldType.OBJECT).optional()
+    );
+
+    public static List<FieldDescriptor> withDataFields(List<FieldDescriptor> dataFields) {
+        return Stream.concat(
+                COMMON_RESPONSE_FIELDS.stream(),
+                dataFields.stream().map(dataField -> {
+                    FieldDescriptor descriptor = fieldWithPath("data." + dataField.getPath())
+                            .description(dataField.getDescription())
+                            .type(dataField.getType());
+                    return dataField.isOptional() ? descriptor.optional() : descriptor;
+                })
+        ).toList();
+    }
+}

--- a/src/test/java/app/pigrest/common/BaseControllerTest.java
+++ b/src/test/java/app/pigrest/common/BaseControllerTest.java
@@ -1,7 +1,10 @@
 package app.pigrest.common;
 
+import app.pigrest.auth.model.Auth;
+import app.pigrest.auth.repository.AuthRepository;
 import app.pigrest.auth.service.JwtService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +21,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-public class BasicControllerTest {
+public class BaseControllerTest {
     @Autowired
     protected ObjectMapper objectMapper;
 
@@ -37,5 +40,10 @@ public class BasicControllerTest {
                 .apply(documentationConfiguration(restDocumentation).operationPreprocessors()
                         .withResponseDefaults())
                 .build();
+    }
+
+    @BeforeAll
+    public static void setupDefaultUser(@Autowired AuthRepository authRepository) {
+        authRepository.save(Auth.of("testUser", "password"));
     }
 }

--- a/src/test/java/app/pigrest/common/BaseControllerTest.java
+++ b/src/test/java/app/pigrest/common/BaseControllerTest.java
@@ -1,10 +1,8 @@
 package app.pigrest.common;
 
-import app.pigrest.auth.model.Auth;
-import app.pigrest.auth.repository.AuthRepository;
+import app.pigrest.auth.model.CustomUser;
 import app.pigrest.auth.service.JwtService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,10 +38,5 @@ public class BaseControllerTest {
                 .apply(documentationConfiguration(restDocumentation).operationPreprocessors()
                         .withResponseDefaults())
                 .build();
-    }
-
-    @BeforeAll
-    public static void setupDefaultUser(@Autowired AuthRepository authRepository) {
-        authRepository.save(Auth.of("testUser", "password"));
     }
 }

--- a/src/test/java/app/pigrest/common/BasicControllerTest.java
+++ b/src/test/java/app/pigrest/common/BasicControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -26,6 +27,9 @@ public class BasicControllerTest {
 
     @MockBean
     protected JwtService jwtService;
+
+    @MockBean
+    protected UserDetailsService userDetailsService;
 
     @BeforeEach
     public void setup(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {

--- a/src/test/java/app/pigrest/common/BasicControllerTest.java
+++ b/src/test/java/app/pigrest/common/BasicControllerTest.java
@@ -1,0 +1,37 @@
+package app.pigrest.common;
+
+import app.pigrest.auth.service.JwtService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+public class BasicControllerTest {
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @MockBean
+    protected JwtService jwtService;
+
+    @BeforeEach
+    public void setup(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation).operationPreprocessors()
+                        .withResponseDefaults())
+                .build();
+    }
+}

--- a/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
+++ b/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -104,5 +105,20 @@ class AuthControllerTest extends BasicControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(cookie().exists("refresh_token"))
                 .andDo(document("login-success", resource(LoginDocs.success())));
+    }
+
+    @Test
+    public void loginFail() throws Exception {
+        LoginRequest request = new LoginRequest("do_noni", "noni");
+        Authentication auth = mock(Authentication.class);
+
+        given(authService.login(any(LoginRequest.class)))
+                .willThrow(new BadCredentialsException("Id or password is incorrect"));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("login-fail", resource(LoginDocs.fail())));
     }
 }

--- a/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
+++ b/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
@@ -9,6 +9,7 @@ import app.pigrest.auth.service.AuthService;
 import app.pigrest.common.ApiResponse;
 import app.pigrest.common.ApiStatusCode;
 import app.pigrest.controller.auth.docs.RegisterDocs;
+import app.pigrest.exception.DuplicateResourceException;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -20,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AuthController.class)
@@ -43,6 +45,36 @@ class AuthControllerTest extends BasicControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andDo(document("register-member-success", resource(RegisterDocs.success())));
+                .andDo(document("register-success", resource(RegisterDocs.success())));
+    }
+
+    @Test
+    public void registerFailWhenDuplicateUsername() throws Exception {
+        RegisterRequest request = new RegisterRequest("lulu_the_piggy", "lulu135!", "lulu135!", "lulu");
+
+        given(authService.checkUsername(anyString()))
+                .willThrow(new DuplicateResourceException("Username is already in use"));
+
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(ApiStatusCode.DUPLICATE_RESOURCE.getStatus()))
+                .andExpect(jsonPath("$.error").value(ApiStatusCode.DUPLICATE_RESOURCE.getCode()))
+                .andDo(document("register-fail-duplicate-username", resource(RegisterDocs.fail())));
+    }
+
+    @Test
+    public void registerFailWhenPasswordMismatch() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "ddo_nonii", "noni135!!", "noni135@@", "noni");
+
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(ApiStatusCode.VALIDATION_ERROR.getStatus()))
+                .andExpect(jsonPath("$.error").value(ApiStatusCode.VALIDATION_ERROR.getCode()))
+                .andDo(document("register-fail-password-mismatch", resource(RegisterDocs.fail())));
     }
 }

--- a/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
+++ b/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
@@ -1,0 +1,48 @@
+package app.pigrest.controller.auth;
+
+import app.pigrest.common.BasicControllerTest;
+import app.pigrest.auth.controller.AuthController;
+import app.pigrest.auth.dto.request.RegisterRequest;
+import app.pigrest.auth.dto.response.RegisterResponse;
+import app.pigrest.auth.model.Auth;
+import app.pigrest.auth.service.AuthService;
+import app.pigrest.common.ApiResponse;
+import app.pigrest.common.ApiStatusCode;
+import app.pigrest.controller.auth.docs.RegisterDocs;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest extends BasicControllerTest {
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    public void registerSuccess() throws Exception {
+        RegisterRequest request = new RegisterRequest("lulu_the_piggy", "lulu135!", "lulu135!", "lulu");
+
+        given(authService.checkUsername(anyString())).willReturn(true);
+
+        Auth auth = Auth.of(request.getUsername(), request.getPassword());
+        given(authService.create(any(RegisterRequest.class))).willReturn(auth);
+
+        ApiResponse<RegisterResponse> response = ApiResponse.success(
+                ApiStatusCode.CREATED, "Member registered successfully", RegisterResponse.from(auth));
+
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("register-member-success", resource(RegisterDocs.success())));
+    }
+}

--- a/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
+++ b/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
@@ -2,7 +2,7 @@ package app.pigrest.controller.auth;
 
 import app.pigrest.auth.dto.request.LoginRequest;
 import app.pigrest.auth.model.CustomUser;
-import app.pigrest.common.BasicControllerTest;
+import app.pigrest.common.BaseControllerTest;
 import app.pigrest.auth.controller.AuthController;
 import app.pigrest.auth.dto.request.RegisterRequest;
 import app.pigrest.auth.dto.response.RegisterResponse;
@@ -34,7 +34,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthController.class)
-class AuthControllerTest extends BasicControllerTest {
+class AuthControllerTest extends BaseControllerTest {
     @MockBean
     private AuthService authService;
 

--- a/src/test/java/app/pigrest/controller/auth/docs/LoginDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/LoginDocs.java
@@ -1,0 +1,42 @@
+package app.pigrest.controller.auth.docs;
+
+
+import app.pigrest.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.HeaderDescriptorWithType;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class LoginDocs {
+
+    private static final List<FieldDescriptor> REQUEST_FIELDS = List.of(
+            fieldWithPath("username").description("사용자 인증 아이디").type(SimpleType.STRING),
+            fieldWithPath("password").description("사용자 인증 패스워드").type(SimpleType.STRING)
+    );
+
+    private static final List<HeaderDescriptorWithType> RESPONSE_HEADERS = List.of(
+            headerWithName("Set-Cookie").description("Refresh token cookie. HttpOnly, Secure, Max-Age=7d, Path=/")
+    );
+
+    private static final List<FieldDescriptor> RESPONSE_FIELDS = List.of(
+            fieldWithPath("accessToken").description("액세스 토큰").type(SimpleType.STRING),
+            fieldWithPath("username").description("사용자 인증 아이디").type(SimpleType.STRING)
+    );
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .summary("로그인")
+                .tag("login")
+                .description("로그인 성공 시, access token과 username을 반환합니다.")
+                .requestFields(REQUEST_FIELDS)
+                .responseHeaders(RESPONSE_HEADERS)
+                .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
+                .build();
+    }
+
+}

--- a/src/test/java/app/pigrest/controller/auth/docs/LoginDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/LoginDocs.java
@@ -39,4 +39,11 @@ public class LoginDocs {
                 .build();
     }
 
+    public static ResourceSnippetParameters fail() {
+        return ResourceSnippetParameters.builder()
+                .tag("login")
+                .requestFields(REQUEST_FIELDS)
+                .responseFields(ApiResponseDocs.COMMON_RESPONSE_FIELDS)
+                .build();
+    }
 }

--- a/src/test/java/app/pigrest/controller/auth/docs/RegisterDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/RegisterDocs.java
@@ -24,10 +24,18 @@ public class RegisterDocs {
     public static ResourceSnippetParameters success() {
         return ResourceSnippetParameters.builder()
                 .summary("회원 등록")
-                .tags("register")
+                .tag("register")
                 .description("회원 등록 성공 시, username을 반환합니다.")
                 .requestFields(REQUEST_FIELDS)
                 .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
+                .build();
+    }
+
+    public static ResourceSnippetParameters fail() {
+        return ResourceSnippetParameters.builder()
+                .tag("register")
+                .requestFields(REQUEST_FIELDS)
+                .responseFields(ApiResponseDocs.COMMON_RESPONSE_FIELDS)
                 .build();
     }
 }

--- a/src/test/java/app/pigrest/controller/auth/docs/RegisterDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/RegisterDocs.java
@@ -1,0 +1,33 @@
+package app.pigrest.controller.auth.docs;
+
+import app.pigrest.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import java.util.List;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class RegisterDocs {
+    private static final List<FieldDescriptor> REQUEST_FIELDS = List.of(
+        fieldWithPath("username").description("사용자 인증 아이디").type(SimpleType.STRING),
+        fieldWithPath("password").description("사용자 인증 패스워드").type(SimpleType.STRING),
+        fieldWithPath("passwordConfirm").description("확인용 비밀번호").type(SimpleType.STRING),
+        fieldWithPath("nickname").description("닉네임").type(SimpleType.STRING)
+    );
+
+    private static final List<FieldDescriptor> RESPONSE_FIELDS = List.of(
+        fieldWithPath("username").description("사용자 인증 아이디").type(SimpleType.STRING)
+    );
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .summary("회원 등록")
+                .tags("register")
+                .description("회원 등록 성공 시, username을 반환합니다.")
+                .requestFields(REQUEST_FIELDS)
+                .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
+                .build();
+    }
+}

--- a/src/test/java/app/pigrest/controller/content/PinControllerTest.java
+++ b/src/test/java/app/pigrest/controller/content/PinControllerTest.java
@@ -1,6 +1,7 @@
-package app.pigrest.content.controller;
+package app.pigrest.controller.content;
 
 import app.pigrest.auth.service.JwtService;
+import app.pigrest.content.controller.PinController;
 import app.pigrest.content.model.Pin;
 import app.pigrest.content.service.PinService;
 import com.epages.restdocs.apispec.ResourceDocumentation;
@@ -16,7 +17,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -42,7 +43,7 @@ class PinControllerTest {
     public void getPinTest() throws Exception {
         Pin pin = new Pin(1L, "Test Pin"); // 가짜 데이터 생성
 
-        when(pinService.getPinById(1L)).thenReturn(pin); // Service 동작 정의
+        given(pinService.getPinById(1L)).willReturn(pin); // Service 동작 정의
 
         mockMvc.perform(get("/pins/{id}", 1))
                 .andExpect(status().isOk())

--- a/src/test/java/app/pigrest/controller/content/PinControllerTest.java
+++ b/src/test/java/app/pigrest/controller/content/PinControllerTest.java
@@ -1,55 +1,42 @@
 package app.pigrest.controller.content;
 
-import app.pigrest.auth.service.JwtService;
+import app.pigrest.common.BaseControllerTest;
 import app.pigrest.content.controller.PinController;
 import app.pigrest.content.model.Pin;
 import app.pigrest.content.service.PinService;
+import app.pigrest.security.WithMockCustomUser;
 import com.epages.restdocs.apispec.ResourceDocumentation;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockCustomUser
 @WebMvcTest(PinController.class)
-@AutoConfigureRestDocs
-@ExtendWith(RestDocumentationExtension.class)
-class PinControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
+class PinControllerTest extends BaseControllerTest {
 
     @MockBean
     private PinService pinService;
 
-    @MockBean
-    private JwtService jwtService; // 의존성 충족
-
     @Test
-    @WithMockUser(username = "testUser", roles = "USER")
     public void getPinTest() throws Exception {
         Pin pin = new Pin(1L, "Test Pin"); // 가짜 데이터 생성
 
         given(pinService.getPinById(1L)).willReturn(pin); // Service 동작 정의
 
-        mockMvc.perform(get("/pins/{id}", 1))
+        mockMvc.perform(get("/pins/{id}", 1)
+                        .header("Authorization", "Bearer "))
                 .andExpect(status().isOk())
+                .andDo(print())
                 .andDo(document("get-pin",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
                         ResourceDocumentation.resource(
                                 ResourceSnippetParameters.builder()
                                         .summary("핀 상세 조회 API")

--- a/src/test/java/app/pigrest/security/WithMockCustomUser.java
+++ b/src/test/java/app/pigrest/security/WithMockCustomUser.java
@@ -1,0 +1,21 @@
+package app.pigrest.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    String id() default "00000000-0000-0000-0000-000000000000";
+
+    String username() default "noni";
+
+    String password() default "password";
+
+    String[] roles() default {"USER"};
+}

--- a/src/test/java/app/pigrest/security/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/app/pigrest/security/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,33 @@
+package app.pigrest.security;
+
+import app.pigrest.auth.model.CustomUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        String username = annotation.username();
+        String password = annotation.password();
+        List<SimpleGrantedAuthority> authorities = Stream.of(annotation.roles())
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                .toList();
+        UUID id = UUID.fromString(annotation.id());
+
+        CustomUser principal = new CustomUser(username, password, authorities, id);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(principal, password, authorities);
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(auth);
+
+        return context;
+    }
+}


### PR DESCRIPTION
테스트 관련
- 컨트롤러 테스트 및 문서화 코드 작성
  - 회원가입: 성공, 실패(유효성 검증)
  - 로그인: 성공, 실패
- 테스트 코드 최적화
  - `ApiResponseDocs` : 공통 응답 필드와 data 하위 필드 문서화를 위한 유틸 클래스 작성
  - `BaseControllerTest` : 중복 코드 제거를 위한 공통 클래스 작성
- `@WithMockCustomUser` : 인증이 필요한 테스트를 위한 Custom Annotation 및 Factory 구현

테스트 외
- application-prod.yaml 오타 수정
- Swagger UI에 Authorize 버튼 추가 (Header에 Authorization Bearer token 추가하기 위함)
- 테스트 패키지 구조 변경