### PR TITLE
[test] 토큰 재발급, 아이디 중복 체크 테스트 작성

### DIFF
--- a/src/main/java/app/pigrest/auth/controller/AuthController.java
+++ b/src/main/java/app/pigrest/auth/controller/AuthController.java
@@ -11,7 +11,9 @@ import app.pigrest.common.ApiResponse;
 import app.pigrest.common.ApiStatusCode;
 import app.pigrest.auth.dto.request.RegisterRequest;
 import app.pigrest.auth.service.AuthService;
+import app.pigrest.common.TokenType;
 import app.pigrest.exception.DuplicateResourceException;
+import app.pigrest.exception.MissingTokenException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -88,7 +90,7 @@ public class AuthController {
                     .map(Cookie::getValue))
                 .ifPresent(jwtService::revokeRefreshToken);
 
-        ResponseCookie deleteCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, null)
+        ResponseCookie deleteCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
                 .path("/")
                 .maxAge(0)
                 .httpOnly(true)
@@ -105,7 +107,7 @@ public class AuthController {
                         .filter(c -> c.getName().equals(REFRESH_TOKEN_COOKIE_NAME))
                         .findFirst()
                         .map(Cookie::getValue))
-                .orElseThrow(() -> new IllegalArgumentException("Refresh token missing"));
+                .orElseThrow(() -> new MissingTokenException(TokenType.REFRESH, "Refresh token is missing"));
         String username = jwtService.validateRefreshToken(refreshToken);
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 

--- a/src/main/java/app/pigrest/auth/dto/request/CheckUsernameRequest.java
+++ b/src/main/java/app/pigrest/auth/dto/request/CheckUsernameRequest.java
@@ -3,9 +3,13 @@ package app.pigrest.auth.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class CheckUsernameRequest {
     @NotBlank(message = "Username must not be blank")
     @Size(min = 4, max = 16, message = "Username must be between 4 and 16 characters")

--- a/src/main/java/app/pigrest/common/ApiStatusCode.java
+++ b/src/main/java/app/pigrest/common/ApiStatusCode.java
@@ -16,7 +16,7 @@ public enum ApiStatusCode {
 
     // 401: 인증 오류
     UNAUTHORIZED(401, "UNAUTHORIZED"),
-    TOKEN_EXPIRED(401, "TOKEN_EXPIRED"),
+    INVALID_TOKEN(401, "INVALID_TOKEN"),
 
     // 403: 권한 오류
     FORBIDDEN(403, "FORBIDDEN"),

--- a/src/main/java/app/pigrest/common/TokenType.java
+++ b/src/main/java/app/pigrest/common/TokenType.java
@@ -1,0 +1,6 @@
+package app.pigrest.common;
+
+public enum TokenType {
+    ACCESS,
+    REFRESH
+}

--- a/src/main/java/app/pigrest/config/JwtAuthenticationFilter.java
+++ b/src/main/java/app/pigrest/config/JwtAuthenticationFilter.java
@@ -16,16 +16,28 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final List<String> whiteListUrls = List.of(
+            "/v3/api-docs/",
+            "/openapi3.yaml",
+            "/swagger-ui",
+            "/auth"
+    );
+
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
 
+    private boolean isWhitelistedUrl(String servletPath) {
+        return whiteListUrls.stream().anyMatch(servletPath::contains);
+    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        if (request.getServletPath().contains("/auth")) {
+        if (isWhitelistedUrl(request.getServletPath())) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/app/pigrest/config/SecurityConfig.java
+++ b/src/main/java/app/pigrest/config/SecurityConfig.java
@@ -27,7 +27,6 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/swagger-ui/**",
             "/auth/**",
-            "/login"
     };
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/app/pigrest/exception/CustomJwtException.java
+++ b/src/main/java/app/pigrest/exception/CustomJwtException.java
@@ -1,0 +1,15 @@
+package app.pigrest.exception;
+
+import app.pigrest.common.TokenType;
+import io.jsonwebtoken.JwtException;
+import lombok.Getter;
+
+@Getter
+public class CustomJwtException extends JwtException {
+    private final TokenType tokenType;
+
+    public CustomJwtException(TokenType tokenType, String message) {
+        super(message);
+        this.tokenType = tokenType;
+    }
+}

--- a/src/main/java/app/pigrest/exception/ExpiredTokenException.java
+++ b/src/main/java/app/pigrest/exception/ExpiredTokenException.java
@@ -1,0 +1,11 @@
+package app.pigrest.exception;
+
+import app.pigrest.common.TokenType;
+import lombok.Getter;
+
+@Getter
+public class ExpiredTokenException extends CustomJwtException {
+    public ExpiredTokenException(TokenType tokenType) {
+        super(tokenType, tokenType + " token has expired");
+    }
+}

--- a/src/main/java/app/pigrest/exception/GlobalExceptionHandler.java
+++ b/src/main/java/app/pigrest/exception/GlobalExceptionHandler.java
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ApiStatusCode.INVALID_TOKEN, ex.getMessage()));
     }
 
-    @ExceptionHandler()
+    @ExceptionHandler(JwtException.class)
     public ResponseEntity<ApiResponse<Object>> handleJwtException(JwtException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.error(ApiStatusCode.INVALID_TOKEN, ex.getMessage()));

--- a/src/main/java/app/pigrest/exception/GlobalExceptionHandler.java
+++ b/src/main/java/app/pigrest/exception/GlobalExceptionHandler.java
@@ -2,7 +2,11 @@ package app.pigrest.exception;
 
 import app.pigrest.common.ApiResponse;
 import app.pigrest.common.ApiStatusCode;
+import app.pigrest.common.TokenType;
+import io.jsonwebtoken.JwtException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -19,6 +23,29 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException ex) {
         // 예외 객체에 포함된 ApiStatusCode와 메시지를 이용해 에러 응답 생성
         return ResponseEntity.ok(ApiResponse.error(ex.getStatusCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler({ InvalidTokenException.class, ExpiredTokenException.class })
+    public ResponseEntity<ApiResponse<Object>> handleTokenException(CustomJwtException ex) {
+        if (ex.getTokenType().equals(TokenType.REFRESH)) {
+            ResponseCookie deleteCookie = ResponseCookie.from("refresh_token", "")
+                    .path("/")
+                    .maxAge(0)
+                    .httpOnly(true)
+                    .build();
+
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+                    .body(ApiResponse.error(ApiStatusCode.INVALID_TOKEN, ex.getMessage()));
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error(ApiStatusCode.INVALID_TOKEN, ex.getMessage()));
+    }
+
+    @ExceptionHandler()
+    public ResponseEntity<ApiResponse<Object>> handleJwtException(JwtException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error(ApiStatusCode.INVALID_TOKEN, ex.getMessage()));
     }
 
     @ExceptionHandler(DuplicateResourceException.class)

--- a/src/main/java/app/pigrest/exception/InvalidTokenException.java
+++ b/src/main/java/app/pigrest/exception/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package app.pigrest.exception;
+
+import app.pigrest.common.TokenType;
+import lombok.Getter;
+
+@Getter
+public class InvalidTokenException extends CustomJwtException {
+    public InvalidTokenException(TokenType tokenType, String message) {
+        super(tokenType, message);
+    }
+}

--- a/src/main/java/app/pigrest/exception/MissingTokenException.java
+++ b/src/main/java/app/pigrest/exception/MissingTokenException.java
@@ -1,0 +1,11 @@
+package app.pigrest.exception;
+
+import app.pigrest.common.TokenType;
+import lombok.Getter;
+
+@Getter
+public class MissingTokenException extends CustomJwtException {
+    public MissingTokenException(TokenType tokenType, String message) {
+        super(tokenType, message);
+    }
+}

--- a/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
+++ b/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package app.pigrest.controller.auth;
 
+import app.pigrest.auth.dto.request.CheckUsernameRequest;
 import app.pigrest.auth.dto.request.LoginRequest;
 import app.pigrest.auth.model.CustomUser;
 import app.pigrest.common.BaseControllerTest;
@@ -11,10 +12,7 @@ import app.pigrest.auth.service.AuthService;
 import app.pigrest.common.ApiResponse;
 import app.pigrest.common.ApiStatusCode;
 import app.pigrest.common.TokenType;
-import app.pigrest.controller.auth.docs.LoginDocs;
-import app.pigrest.controller.auth.docs.LogoutDocs;
-import app.pigrest.controller.auth.docs.RefreshDocs;
-import app.pigrest.controller.auth.docs.RegisterDocs;
+import app.pigrest.controller.auth.docs.*;
 import app.pigrest.exception.DuplicateResourceException;
 import app.pigrest.exception.ExpiredTokenException;
 import app.pigrest.exception.InvalidTokenException;
@@ -27,6 +25,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 
 import java.util.List;
@@ -209,5 +208,18 @@ class AuthControllerTest extends BaseControllerTest {
                 .andExpect(status().isUnauthorized())
                 .andDo(document("refresh-fail-expired-token", resource(RefreshDocs.fail())));
 
+    }
+
+    @Test
+    public void checkUsernameSuccess() throws Exception {
+        CheckUsernameRequest request = new CheckUsernameRequest("ddo_nonii");
+
+        given(authService.checkUsername(request.getUsername())).willReturn(true);
+
+        mockMvc.perform(post("/auth/check-username")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("check-username-success", resource(CheckUsernameDocs.success())));
     }
 }

--- a/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
+++ b/src/test/java/app/pigrest/controller/auth/AuthControllerTest.java
@@ -12,8 +12,10 @@ import app.pigrest.common.ApiResponse;
 import app.pigrest.common.ApiStatusCode;
 import app.pigrest.controller.auth.docs.LoginDocs;
 import app.pigrest.controller.auth.docs.LogoutDocs;
+import app.pigrest.controller.auth.docs.RefreshDocs;
 import app.pigrest.controller.auth.docs.RegisterDocs;
 import app.pigrest.exception.DuplicateResourceException;
+import app.pigrest.security.WithMockCustomUser;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -149,5 +151,24 @@ class AuthControllerTest extends BaseControllerTest {
                         resource(LogoutDocs.success())));
 
         verify(jwtService, never()).revokeRefreshToken(any());
+    }
+
+    @Test
+    public void refreshSuccess() throws Exception {
+        String username = "ddo_nonii";
+        String refreshToken = "refresh-token-value";
+        String newAccessToken = "new-access-token-value";
+
+        Cookie cookie = new Cookie("refresh_token", refreshToken);
+        UserDetails userDetails = new CustomUser(username, "password", List.of(), null);
+
+        given(jwtService.validateRefreshToken(refreshToken)).willReturn(username);
+        given(userDetailsService.loadUserByUsername(username)).willReturn(userDetails);
+        given(jwtService.generateAccessToken(userDetails)).willReturn(newAccessToken);
+
+        mockMvc.perform(post("/auth/refresh")
+                        .cookie(cookie))
+                .andExpect(status().isOk())
+                .andDo(document("refresh-success", resource(RefreshDocs.success())));
     }
 }

--- a/src/test/java/app/pigrest/controller/auth/docs/CheckUsernameDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/CheckUsernameDocs.java
@@ -1,0 +1,38 @@
+package app.pigrest.controller.auth.docs;
+
+import app.pigrest.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import java.util.List;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class CheckUsernameDocs {
+    private static final List<FieldDescriptor> REQUEST_FIELDS = List.of(
+            fieldWithPath("username").description("사용자 인증 아이디").type(SimpleType.STRING)
+    );
+
+    private static final List<FieldDescriptor> RESPONSE_FIELDS = List.of(
+            fieldWithPath("isAvailable").description("사용 가능 여부").type(SimpleType.BOOLEAN)
+    );
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .summary("아이디 중복 체크")
+                .description("아이디(username) 사용 가능 여부를 반환합니다.<br>" +
+                        "유효성 검사에서 실패 시, 400 상태 코드(VALIDATION_ERROR)를 반환합니다.<br>" +
+                        "아이디는 4 글자와 16 글자 사이여야 하고, 소문자/숫자/언더스코어(_)만 사용 가능합니다.")
+                .requestFields(REQUEST_FIELDS)
+                .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
+                .build();
+    }
+
+    public static ResourceSnippetParameters fail() {
+        return ResourceSnippetParameters.builder()
+                .requestFields(REQUEST_FIELDS)
+                .responseFields(ApiResponseDocs.COMMON_RESPONSE_FIELDS)
+                .build();
+    }
+}

--- a/src/test/java/app/pigrest/controller/auth/docs/LoginDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/LoginDocs.java
@@ -31,7 +31,6 @@ public class LoginDocs {
     public static ResourceSnippetParameters success() {
         return ResourceSnippetParameters.builder()
                 .summary("로그인")
-                .tag("login")
                 .description("로그인 성공 시, access token과 username을 반환합니다.")
                 .requestFields(REQUEST_FIELDS)
                 .responseHeaders(RESPONSE_HEADERS)
@@ -41,7 +40,6 @@ public class LoginDocs {
 
     public static ResourceSnippetParameters fail() {
         return ResourceSnippetParameters.builder()
-                .tag("login")
                 .requestFields(REQUEST_FIELDS)
                 .responseFields(ApiResponseDocs.COMMON_RESPONSE_FIELDS)
                 .build();

--- a/src/test/java/app/pigrest/controller/auth/docs/LogoutDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/LogoutDocs.java
@@ -1,0 +1,15 @@
+package app.pigrest.controller.auth.docs;
+
+import app.pigrest.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+
+public class LogoutDocs {
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .summary("로그아웃")
+                .description("Cookie에 refresh token이 없어도, 로그아웃을 진행합니다.")
+                .responseFields(ApiResponseDocs.COMMON_RESPONSE_FIELDS)
+                .build();
+    }
+}

--- a/src/test/java/app/pigrest/controller/auth/docs/RefreshDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/RefreshDocs.java
@@ -1,0 +1,33 @@
+package app.pigrest.controller.auth.docs;
+
+import app.pigrest.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import java.util.List;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class RefreshDocs {
+    private static final List<FieldDescriptor> RESPONSE_FIELDS = List.of(
+            fieldWithPath("accessToken").description("액세스 토큰").type(SimpleType.STRING),
+            fieldWithPath("username").description("사용자 인증 아이디").type(SimpleType.STRING)
+    );
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .summary("토큰 재발급")
+                .description("Access Token 만료 시, Cookie에 저장되어 있는 Refresh Token을 활용하여 토큰을 재발급할 수 있습니다.<br>" +
+                        "Cookie에 저장된 Refresh Token이 유효하다면 Access Token을 재발급해줍니다.<br>" +
+                        "유효하지 않은 토큰이거나 Refresh token이 쿠키에 존재하지 않는다면 401 상태 코드가 반환됩니다.")
+                .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
+                .build();
+    }
+
+    public static ResourceSnippetParameters fail() {
+        return ResourceSnippetParameters.builder()
+                .responseFields(ApiResponseDocs.COMMON_RESPONSE_FIELDS)
+                .build();
+    }
+}

--- a/src/test/java/app/pigrest/controller/auth/docs/RefreshDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/RefreshDocs.java
@@ -20,7 +20,7 @@ public class RefreshDocs {
                 .summary("토큰 재발급")
                 .description("Access Token 만료 시, Cookie에 저장되어 있는 Refresh Token을 활용하여 토큰을 재발급할 수 있습니다.<br>" +
                         "Cookie에 저장된 Refresh Token이 유효하다면 Access Token을 재발급해줍니다.<br>" +
-                        "유효하지 않은 토큰이거나 Refresh token이 쿠키에 존재하지 않는다면 401 상태 코드가 반환됩니다.")
+                        "(1)만료된 토큰 (2)유효하지 않은 토큰 (3)Refresh token이 쿠키에 존재하지 않은 경우, 401 상태 코드가 반환됩니다.")
                 .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
                 .build();
     }

--- a/src/test/java/app/pigrest/controller/auth/docs/RegisterDocs.java
+++ b/src/test/java/app/pigrest/controller/auth/docs/RegisterDocs.java
@@ -24,7 +24,6 @@ public class RegisterDocs {
     public static ResourceSnippetParameters success() {
         return ResourceSnippetParameters.builder()
                 .summary("회원 등록")
-                .tag("register")
                 .description("회원 등록 성공 시, username을 반환합니다.")
                 .requestFields(REQUEST_FIELDS)
                 .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
@@ -33,7 +32,6 @@ public class RegisterDocs {
 
     public static ResourceSnippetParameters fail() {
         return ResourceSnippetParameters.builder()
-                .tag("register")
                 .requestFields(REQUEST_FIELDS)
                 .responseFields(ApiResponseDocs.COMMON_RESPONSE_FIELDS)
                 .build();


### PR DESCRIPTION
- 컨트롤러 테스트 및 문서화 코드 작성
  - 토큰 재발급: 성공, 실패(유효하지 않은 토큰, 만료된 토큰, Cookie에 없는 경우)
  - 아이디 중복 체크: 성공

- 사용자 정의 Exception 및 Handler 추가
  - CustomJwtException
    - MissingTokenException
    - InvalidTokenException
    - ExpiredTokenException